### PR TITLE
IGAPP-94: Update react-native-image-zoom-viewer

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -60,7 +60,7 @@
     "react-native-fast-image": "^7.0.2",
     "react-native-gesture-handler": "~1.5.6",
     "react-native-highlight-words": "^1.0.1",
-    "react-native-image-zoom-viewer": "^2.2.27",
+    "react-native-image-zoom-viewer": "^3.0.1",
     "react-native-pdf": "6.2.0",
     "react-native-permissions": "2.0.9",
     "react-native-progress": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13854,17 +13854,17 @@ react-native-highlight-words@^1.0.1:
     highlight-words-core "^1.0.3"
     prop-types "^15.5.7"
 
-react-native-image-pan-zoom@^2.1.9:
+react-native-image-pan-zoom@^2.1.12:
   version "2.1.12"
   resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
   integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
 
-react-native-image-zoom-viewer@^2.2.27:
-  version "2.2.27"
-  resolved "https://registry.yarnpkg.com/react-native-image-zoom-viewer/-/react-native-image-zoom-viewer-2.2.27.tgz#fb3314c5dc86ac33da48cb31bf4920d97eecb6eb"
-  integrity sha512-BMA8ZGe6dub9mPbGhFn14eAnq8H5ig32nY9vPqTjsJluLTcwjkMjupu47dha1ikK7vFo0zpGDFKlv2WHbtf+EQ==
+react-native-image-zoom-viewer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-image-zoom-viewer/-/react-native-image-zoom-viewer-3.0.1.tgz#a2bd5fb3bda15e0686ce88fcde8576726495d7fb"
+  integrity sha512-la6s5DNSuq4GCRLsi5CZ29FPjgTpdCuGIRdO5T9rUrAtxrlpBPhhSnHrbmPVxsdtOUvxHacTh2Gfa9+RraMZQA==
   dependencies:
-    react-native-image-pan-zoom "^2.1.9"
+    react-native-image-pan-zoom "^2.1.12"
 
 react-native-pdf@6.2.0:
   version "6.2.0"


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

The issue claimed, that the package uses deprecated features, but those seem to be removed starting version 3.0.0. Convince yourself if you don't believe me though 😸 