### PR TITLE
APICLIENT-41: http://integreat/ is not a valid URL

### DIFF
--- a/web/.idea/runConfigurations/Debug_with_Chrome.xml
+++ b/web/.idea/runConfigurations/Debug_with_Chrome.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug with Chrome" type="JavascriptDebugType" uri="http://localhost:9000/">
+    <method v="2" />
+  </configuration>
+</component>

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.7.2",
     "@fortawesome/free-solid-svg-icons": "^5.7.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@integreat-app/integreat-api-client": "^6.0.0",
+    "@integreat-app/integreat-api-client": "^6.0.1",
     "@integreat-app/react-sticky-headroom": "^1.0.4",
     "detect-browser": "^4.1.0",
     "focus-trap-react": "^6.0.0",


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
