### PR TITLE
IGAPP-368: Bundle size to big

### DIFF
--- a/web/tools/webpack.config.babel.js
+++ b/web/tools/webpack.config.babel.js
@@ -22,7 +22,7 @@ const SHORT_COMMIT_SHA_LENGTH = 8
 
 // A first performance budget, which should be improved in the future: Maximum bundle size in Bytes; 2^20 = 1 MiB
 // eslint-disable-next-line no-magic-numbers
-const MAX_BUNDLE_SIZE = 1.56 * Math.pow(2, 20)
+const MAX_BUNDLE_SIZE = 1.62 * Math.pow(2, 20)
 
 const readJson = path => JSON.parse(fs.readFileSync(path))
 


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

The max bundle size has to be increased since the api-client package in the monorepo than the built version from npm was before. This is because previously the files were built, which does not happen anymore now. The api-client package has now a size of 100.93 KiB in comparison to 33.58 KiB before. The increase of the budget by 0.6 MiB is enough since the budget wasn't used completely before.