### PR TITLE
IGAPP-375: Fix babel transpile error in decamelize npm

### DIFF
--- a/native/babel.config.js
+++ b/native/babel.config.js
@@ -11,6 +11,8 @@ module.exports = {
       plugins: ['transform-remove-console']
     }
   },
+  // prevent babel error - only windows (using backslash)
+  exclude: [/node_modules\\decamelize.*/],
   plugins: [
     [
       'transform-inline-environment-variables',


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
