### PR TITLE
IGAPP-124: Disable data detection in iOS webview

### DIFF
--- a/native/src/modules/common/components/RemoteContent.js
+++ b/native/src/modules/common/components/RemoteContent.js
@@ -80,7 +80,7 @@ class RemoteContent extends React.Component<PropType, StateType> {
         source={createHtmlSource(renderHtml(content, cacheDirectory, theme, language), resourceCacheUrl)}
         originWhitelist={['*']} // Needed by iOS to load the initial html
         javaScriptEnabled
-        dataDetectorTypes='all'
+        dataDetectorTypes='none'
         domStorageEnabled={false}
         showsVerticalScrollIndicator={false}
         showsHorizontalScrollIndicator={false}

--- a/native/src/routes/external-offer/components/ExternalOffer.js
+++ b/native/src/routes/external-offer/components/ExternalOffer.js
@@ -20,7 +20,7 @@ class ExternalOffer extends React.Component<PropsType> {
     return <WebView
       source={postData ? createPostSource(url, body) : createGetSource(url, body)}
       javaScriptEnabled
-      dataDetectorTypes={['all']}
+      dataDetectorTypes='none'
       domStorageEnabled={false}
       renderError={this.renderError}
     />

--- a/web/src/index.ejs
+++ b/web/src/index.ejs
@@ -25,6 +25,10 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+  <!-- Disable phone number auto detection in mobile safari in order to have consistent behavior -->
+  <!-- https://developers.google.com/web/fundamentals/native-hardware/click-to-call#disable_auto-detection_when_necessary -->
+  <meta name="format-detection" content="telephone=no">
+
   <link rel="dns-prefetch" href="<%= config.cmsUrl %>" />
   <link rel="preconnect" href="<%= config.cmsUrl %>" />
 


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

See discussion here: https://tuerantuer.slack.com/archives/CDV9QF1GA/p1587050318013000
This seems not to happen anymore, but we think disabling is still the best option.

API reference: https://github.com/react-native-webview/react-native-webview/blob/d4ab332891af2242e663ac2e25f4aa3317945399/docs/Reference.md#datadetectortypes