### PR TITLE
IGAPP-194: Stabilize e2e tests

### DIFF
--- a/native/e2e/config/configs.js
+++ b/native/e2e/config/configs.js
@@ -71,15 +71,15 @@ exports.browserstack_ci_android = {
   prefix: 'IG CI',
   platform: 'android',
   caps: {
+    'browserstack.appium_version': '1.18.0',
+    'browserstack.debug': true,
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,
     project: 'integreat-react-native-app',
     os_version: '9.0',
     device: 'Google Pixel 3',
-    real_mobile: 'true',
-    'browserstack.appium_version': '1.17.0',
     app: process.env.E2E_BROWSERSTACK_APP,
-    'browserstack.debug': true
+    real_mobile: 'true'
   }
 }
 
@@ -88,14 +88,15 @@ exports.browserstack_ci_ios = {
   prefix: 'IG CI',
   platform: 'ios',
   caps: {
+    'browserstack.appium_version': '1.18.0',
+    'browserstack.debug': true,
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,
     project: 'integreat-react-native-app',
     os_version: '11',
     device: 'iPhone 8',
     real_mobile: 'true',
-    'browserstack.appium_version': '1.16.0',
     app: process.env.E2E_BROWSERSTACK_APP,
-    'browserstack.debug': true
+    waitForQuiescence: false
   }
 }

--- a/native/e2e/config/configs.js
+++ b/native/e2e/config/configs.js
@@ -88,7 +88,7 @@ exports.browserstack_ci_ios = {
   prefix: 'IG CI',
   platform: 'ios',
   caps: {
-    'browserstack.appium_version': '1.15.0',
+    'browserstack.appium_version': '1.16.0',
     'browserstack.debug': true,
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,
@@ -96,6 +96,7 @@ exports.browserstack_ci_ios = {
     os_version: '11',
     device: 'iPhone 8',
     real_mobile: 'true',
-    app: process.env.E2E_BROWSERSTACK_APP
+    app: process.env.E2E_BROWSERSTACK_APP,
+    waitForQuiescence: 'true'
   }
 }

--- a/native/e2e/config/configs.js
+++ b/native/e2e/config/configs.js
@@ -88,7 +88,7 @@ exports.browserstack_ci_ios = {
   prefix: 'IG CI',
   platform: 'ios',
   caps: {
-    'browserstack.appium_version': '1.16.0',
+    'browserstack.appium_version': '1.15.0',
     'browserstack.debug': true,
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,
@@ -96,7 +96,6 @@ exports.browserstack_ci_ios = {
     os_version: '11',
     device: 'iPhone 8',
     real_mobile: 'true',
-    app: process.env.E2E_BROWSERSTACK_APP,
-    waitForQuiescence: false
+    app: process.env.E2E_BROWSERSTACK_APP
   }
 }

--- a/native/e2e/config/configs.js
+++ b/native/e2e/config/configs.js
@@ -71,7 +71,7 @@ exports.browserstack_ci_android = {
   prefix: 'IG CI',
   platform: 'android',
   caps: {
-    'browserstack.appium_version': '1.18.0',
+    'browserstack.appium_version': '1.17.0',
     'browserstack.debug': true,
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,
@@ -88,7 +88,7 @@ exports.browserstack_ci_ios = {
   prefix: 'IG CI',
   platform: 'ios',
   caps: {
-    'browserstack.appium_version': '1.18.0',
+    'browserstack.appium_version': '1.16.0',
     'browserstack.debug': true,
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Most of the time the ios e2e tests timed out. After looking at the appium logs of the failed tests you could see the error message `Capability 'waitForQuiescence' changed from string to boolean. This may cause unexpected behavior`. After some search I also found that this capability can lead to very slow or even stuck tests (more details [here](https://github.com/appium/appium-xcuitest-driver#desired-capabilities)). I don't think there is a good way to test whether the tests will work more stable after this change though. :)