### PR TITLE
IGAPP-194: Update Version of iOS in E2E test

### DIFF
--- a/native/e2e/config/configs.js
+++ b/native/e2e/config/configs.js
@@ -57,12 +57,13 @@ exports.browserstack_dev_ios = {
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,
     project: 'integreat-react-native-app',
-    os_version: '11',
+    os_version: '12',
     device: 'iPhone 8',
     real_mobile: 'true',
-    'browserstack.appium_version': '1.16.0',
+    'browserstack.appium_version': '1.17.0',
     app: process.env.E2E_BROWSERSTACK_APP,
-    'browserstack.debug': true
+    'browserstack.debug': true,
+    waitForQuiescence: 'true'
   }
 }
 
@@ -88,12 +89,12 @@ exports.browserstack_ci_ios = {
   prefix: 'IG CI',
   platform: 'ios',
   caps: {
-    'browserstack.appium_version': '1.16.0',
+    'browserstack.appium_version': '1.17.0',
     'browserstack.debug': true,
     'browserstack.user': process.env.E2E_BROWSERSTACK_USER,
     'browserstack.key': process.env.E2E_BROWSERSTACK_KEY,
     project: 'integreat-react-native-app',
-    os_version: '11',
+    os_version: '12',
     device: 'iPhone 8',
     real_mobile: 'true',
     app: process.env.E2E_BROWSERSTACK_APP,


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

See discussion here: https://chat.tuerantuer.org/digitalfabrik/pl/e7nedbz6g3869m376e9n3t86tr

I also tried the version 1.18.0 and 1.19.1 but both seemed worse performance wise, as they both seemed to depend on some cached files on the device. Somthing that somehow still throws me off is [this build](https://app.circleci.com/pipelines/github/Integreat/integreat-app/965/workflows/bec0546d-bfbb-4438-a429-d78e555d6daa/jobs/5219) where an unexpected timeout occurs. Besides that the native build failed I cannot see any reason why there would be a timout :/. Maybe one of you has an idea.