### PR TITLE
IGAPP-454: App crashing because of wrong minSDK

### DIFF
--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
         kotlinVersion = "1.3.50" // TODO: Remove in NATIVE-490


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Changed minSDK to 21. Tested on Android 5.0, 6.0, 7.0, 8.0, 9 and 10.