### PR TITLE
IGAPP-557: Android builds failing with exit value 137

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
             - image: circleci/android:api-29-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
-            TOTAL_CPUS: 2
+            TOTAL_CPUS: 3
         parameters:
             build_config_name:
                 default: integreat
@@ -287,7 +287,7 @@ jobs:
                     - integreat-test-cms
                     - aschaffenburg
                 type: enum
-        resource_class: medium
+        resource_class: medium+
         shell: /bin/bash -eo pipefail
         steps:
             - skip_job:

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -5,9 +5,9 @@ parameters:
     default: integreat
 docker:
   - image: circleci/android:api-29-node
-resource_class: medium
+resource_class: medium+
 environment:
-  TOTAL_CPUS: 2 # For resource_class medium, used in metro.config.ci.js.
+  TOTAL_CPUS: 3 # For resource_class medium+, used in metro.config.ci.js. For memory estimations see IGAPP-557
   FASTLANE_SKIP_UPDATE_CHECK: true
 shell: /bin/bash -eo pipefail
 steps:

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -161,6 +161,9 @@ android {
         // https://rnfirebase.io/enabling-multidex
         multiDexEnabled true
     }
+    dexOptions {
+        javaMaxHeapSize "1g" // 2GB Gradle + 1GB dex + 2-2.5GB RN < 6GB of circleci resource class medium+
+    }
     signingConfigs {
         release {
             if (project.hasProperty('KEYSTORE_PATH')) {

--- a/native/android/fastlane/Fastfile
+++ b/native/android/fastlane/Fastfile
@@ -53,7 +53,8 @@ lane :build do |options|
   ENV["BUILD_CONFIG_NAME"] = build_config_name
 
   gradle_system_properties = {
-    :"org.gradle.jvmargs" => "-Xms512m -Xmx1792m",
+    # 2GB Gradle + 1GB dex + 2-2.5GB RN < 6GB of circleci resource class medium+
+    :"org.gradle.jvmargs" => "-Xms512m -Xmx2024m",
     :"org.gradle.daemon" => false
   }
 

--- a/native/android/fastlane/README.md
+++ b/native/android/fastlane/README.md
@@ -1,5 +1,5 @@
-# fastlane documentation
-
+fastlane documentation
+================
 # Installation
 
 Make sure you have the latest version of the Xcode command line tools installed:
@@ -9,40 +9,29 @@ xcode-select --install
 ```
 
 Install _fastlane_ using
-
 ```
 [sudo] gem install fastlane -NV
 ```
-
 or alternatively using `brew install fastlane`
 
 # Available Actions
-
 ### keystore
-
 ```
 fastlane keystore
 ```
-
 Download and decrypt the JKS
-
 ### dependencies
-
 ```
 fastlane dependencies
 ```
-
 Download Gradle dependencies
-
 ### build
-
 ```
 fastlane build
 ```
-
 Create an Android build in release mode. Set the environment variable E2E_TEST_IDS if you want a build usable for E2E tests. Set the environment variable TOTAL_CPUS if you run this in a Docker container.
 
----
+----
 
 This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).


### PR DESCRIPTION
5GB <= 2GB Gradle + 1GB dex + 2-2.5GB RN <= 5.5GB

This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
