### PR TITLE
IGAPP-515: Disable Sentry Sourcemap releases for webnext

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,15 +679,6 @@ jobs:
                     - run:
                         command: sftp -b - -v -o StrictHostKeyChecking=no web@web.integreat-app.de:/webnext.aschaffenburg.app \<<< "put -r $HOME/attached_workspace/dist/aschaffenburg/*"
                         name: Aschaffenburg development delivery
-                    - run:
-                        command: tools/sentry-release web-integreat-test-cms "${NEW_VERSION_NAME}" ~/attached_workspace/dist/integreat-test-cms
-                        name: 'Sentry Upload: integreat-test-cms'
-                    - run:
-                        command: tools/sentry-release web-malte "${NEW_VERSION_NAME}" ~/attached_workspace/dist/malte
-                        name: 'Sentry Upload: malte'
-                    - run:
-                        command: tools/sentry-release web-aschaffenburg "${NEW_VERSION_NAME}" ~/attached_workspace/dist/aschaffenburg
-                        name: 'Sentry Upload: aschaffenburg'
             - notify
     e2e_android:
         docker:

--- a/.circleci/src/jobs/deliver_web.yml
+++ b/.circleci/src/jobs/deliver_web.yml
@@ -48,13 +48,4 @@ steps:
         - run:
             name: Aschaffenburg development delivery
             command: sftp -b - -v -o StrictHostKeyChecking=no web@web.integreat-app.de:/webnext.aschaffenburg.app \<<< "put -r $HOME/attached_workspace/dist/aschaffenburg/*"
-        - run:
-            name: "Sentry Upload: integreat-test-cms"
-            command: tools/sentry-release web-integreat-test-cms "${NEW_VERSION_NAME}" ~/attached_workspace/dist/integreat-test-cms
-        - run:
-            name: "Sentry Upload: malte"
-            command: tools/sentry-release web-malte "${NEW_VERSION_NAME}" ~/attached_workspace/dist/malte
-        - run:
-            name: "Sentry Upload: aschaffenburg"
-            command: tools/sentry-release web-aschaffenburg "${NEW_VERSION_NAME}" ~/attached_workspace/dist/aschaffenburg
   - notify


### PR DESCRIPTION
# This PR should serve as a discussion

The original issue is because we are not bumping versions when we are doing development releases to webnext.
That means we are uploading different sourcemaps to the same release in sentry.
This is not really a big issue as sentry will figure out on which sourcemap the issue happened and use the correct one.

I think we should close the issue and NOT merge this. In fact this is only an issue for aschaffenburg and malte as we do not have different build configs for releases to webnext.malte.app and webnext.aschaffenburg.app.

The proper fix to this issue is probably to include the deployment information for web in the build config. That way we would have different build configs for integreat, malte and aschaffenburg for webnext. Like malte-test-cms and aschaffenburg-test-cms. What do you think about this proper fix?