### PR TITLE
IGAPP-548: Add albanian

### DIFF
--- a/translations/src/config.js
+++ b/translations/src/config.js
@@ -16,6 +16,7 @@ class Config {
   sourceLanguage = 'de'
 
   // The languages into which we translate from 'sourceLanguage' including the sourceLanguage
+  // See https://wiki.tuerantuer.org/integreat-languages and https://iso639-3.sil.org/code_tables/639/data
   supportedLanguages: SupportedLanguagesType = {
     de: { rtl: false },
     ar: {
@@ -55,7 +56,8 @@ class Config {
       rtl: false,
       additionalFont: 'noto-sans-sc'
     },
-    mk: { rtl: false }
+    mk: { rtl: false },
+    sq: { rtl: false }
   }
 
   // Fallbacks for unnormalized language codes from our backend


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Testable here: https://webnext.malteapp.de/nrw/sq tested all "specific" albanian letters (https://en.wikipedia.org/wiki/Albanian_language#Orthography) here https://fonts.google.com/specimen/Open+Sans?preview.text_type=custom#standard-styles, seems like open sans supports all letters.