### PR TITLE
Remove @schedulaar from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for
 # review when someone opens a pull request.
-*       @maxammann @schedulaar @klinzo @nklug @a-kud @Taggotty @lulo4907 @SimonVortkamp @Znippet @SteffiStuffel 
+*       @maxammann @klinzo @nklug @a-kud @Taggotty @lulo4907 @SimonVortkamp @Znippet @SteffiStuffel 


### PR DESCRIPTION
As I currently have no time for reviewing all the numerous, fancy PRs you open, I don't need to be notified by GitHub about them.
I guess this is the only reasonable way to deactivate them, right?