### PR TITLE
[Proposal] IGAPP-664: Only build after checks succeeded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -957,6 +957,7 @@ workflows:
                 name: build_e2e_android
                 requires:
                     - bump_version
+                    - check_native
             - e2e_android:
                 context:
                     - mattermost
@@ -972,6 +973,7 @@ workflows:
                 name: build_e2e_ios
                 requires:
                     - bump_version
+                    - check_native
             - e2e_ios:
                 context:
                     - mattermost

--- a/.circleci/src/workflows/commit.yml
+++ b/.circleci/src/workflows/commit.yml
@@ -15,6 +15,7 @@ jobs:
 #        - mattermost
 #      requires:
 #        - bump_version
+#        - check_web
 #  - build_web:
 #      name: build_malte_web
 #      build_config_name: malte
@@ -22,6 +23,7 @@ jobs:
 #        - mattermost
 #      requires:
 #        - bump_version
+#        - check_web
 #  - build_web:
 #      name: build_aschaffenburg_web
 #      build_config_name: aschaffenburg
@@ -29,6 +31,7 @@ jobs:
 #        - mattermost
 #      requires:
 #        - bump_version
+#        - check_web
 #  - deliver_web:
 #      filters:
 #        branches:
@@ -57,6 +60,7 @@ jobs:
         - tuerantuer-android
       requires:
         - bump_version
+        - check_native
   - e2e_android:
       context:
         - mattermost
@@ -73,6 +77,7 @@ jobs:
         - tuerantuer-ios
       requires:
         - bump_version
+        - check_native
   - e2e_ios:
       context:
         - mattermost


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

**This should be discussed.**

Builds will take even longer with this change (normally ~5mins, with outliers up to 9mins, so probably 50mins instead of 43mins or something like that), but we would probably reduce our credit usage significantly (especially iOS builds are very expensive) if we only build our apps once tests succeeded. I would not merge this if anyone thinks even longer builds are really annoying and not worth the reduced credit usage because it makes it more tedious and time intensive for us. Personally I think I don't really mind since we have the automerge feature enabled anymore but really not very sure about this.

Some numbers:
Total credits used: 1,100,000, with 990,000 (90%) for the commit workflow.
Of these 990,000 credits of the commit workflow the `build_e2e_ios` job is using 805,000 (81%) and the `build_e2e_android` job 95,000 (9.6%) credits. The success rate of commit workflows is 43%. By only running builds after tests we could therefore reduce credit and resource usage quite significantly.
200,000 credits are 120$.

Some more numbers and insights:
https://app.circleci.com/insights/github/Integreat/integreat-app/workflows/commit/jobs?reporting-window=last-90-days&branch=b1d8acd4-8701-4c76-8a87-7ff2320aa95f