### PR TITLE
IGAPP-757: Increase connectionRetryTimeout in E2E Tests

### DIFF
--- a/e2e-tests/native/capabilities.ts
+++ b/e2e-tests/native/capabilities.ts
@@ -10,6 +10,7 @@ const browserstackCaps = (
   const isCi = !!process.env.CI
   const prefix = isCi ? 'IG CI' : 'IG DEV'
   const app = process.env.E2E_BROWSERSTACK_APP
+
   return {
     'bstack:options': {
       buildName: `${prefix}: ${getGitBranch()}`,
@@ -17,8 +18,8 @@ const browserstackCaps = (
       projectName: 'integreat-app-native',
       debug: true,
       realMobile: isCi,
-      networkProfile: '4g-lte-good',
-      appiumVersion: '1.21.0'
+      appiumVersion: '1.21.0',
+      idleTimeout: 10000
     },
     ...config,
     'appium:app': app,
@@ -41,7 +42,7 @@ export default {
       'appium:deviceName': 'iPhone 8',
       'appium:automationName': 'XCUITest',
       // @ts-ignore unknown property
-      'appium:waitForQuiescence': true
+      'appium:waitForIdleTimeout': 10000
     },
     'ios'
   )

--- a/e2e-tests/native/wdio-browserstack.conf.ts
+++ b/e2e-tests/native/wdio-browserstack.conf.ts
@@ -1,3 +1,5 @@
+import { Testrunner } from '@wdio/types/build/Options'
+
 import capabilities from './capabilities'
 
 const getCapability = () => {
@@ -13,32 +15,31 @@ const getCapability = () => {
   return capabilities[capability]
 }
 
-export const config = {
+export const config: Testrunner = {
   runner: 'local',
   specs: ['./native/test/specs/**/*.ts'],
   exclude: [],
 
-  maxInstances: 2,
-
+  maxInstances: 1,
+  maxInstancesPerCapability: 1,
   user: process.env.E2E_BROWSERSTACK_USER,
   key: process.env.E2E_BROWSERSTACK_KEY,
 
   capabilities: [getCapability()],
 
   logLevel: 'info',
-  coloredLogs: true,
-  bail: 0,
+
+  bail: 1,
   baseUrl: 'http://localhost:9000',
   waitforTimeout: 100000,
   waitforInterval: 2000,
-  connectionRetryTimeout: 50000,
-  connectionRetryCount: 3,
-  services: [['browserstack']],
-  host: 'hub.browserstack.com',
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 2,
+  services: ['browserstack'],
   framework: 'jasmine',
   reporters: ['junit'],
 
   jasmineOpts: {
-    defaultTimeoutInterval: 200000
+    defaultTimeoutInterval: 300000
   }
 }

--- a/e2e-tests/native/wdio.conf.ts
+++ b/e2e-tests/native/wdio.conf.ts
@@ -1,4 +1,5 @@
 import { Capabilities } from '@wdio/types/build/Capabilities'
+import { Testrunner } from '@wdio/types/build/Options'
 
 const androidCapabilities: Capabilities = {
   platformName: 'android',
@@ -6,7 +7,7 @@ const androidCapabilities: Capabilities = {
   'appium:automationName': 'UiAutomator2'
 }
 
-export const config = {
+export const config: Testrunner = {
   runner: 'local',
   specs: ['./native/test/specs/**/*.ts'],
   exclude: [],
@@ -16,13 +17,13 @@ export const config = {
   capabilities: [androidCapabilities],
 
   logLevel: 'info',
-  coloredLogs: true,
+
   bail: 0,
   port: 4723, // default appium port
   waitforTimeout: 10000,
   waitforInterval: 2000,
   connectionRetryTimeout: 120000,
-  connectionRetryCount: 3,
+  connectionRetryCount: 2,
   services: ['appium'],
   framework: 'jasmine',
   reporters: ['junit'],

--- a/e2e-tests/web/wdio.conf.ts
+++ b/e2e-tests/web/wdio.conf.ts
@@ -1,6 +1,8 @@
+import { Testrunner } from '@wdio/types/build/Options'
+
 import { localCapabilities } from './capabilities'
 
-export const config = {
+export const config: Testrunner = {
   runner: 'local',
   specs: ['./web/test/specs/**/*.ts'],
   exclude: [],
@@ -8,7 +10,6 @@ export const config = {
 
   capabilities: [process.env.CI ? localCapabilities.ci : localCapabilities.browser],
   logLevel: 'info',
-  coloredLogs: true,
   bail: 0,
   baseUrl: 'http://localhost:9000',
   waitforTimeout: 100000,


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

As always this one cannot guarante, that there will be no more failing tests. But I ran both the ios and the android tests quite often to ensure that they do not time out in 1 of 5 runs, which is about 90% better what we currently have. As I just said increasing the timeout seems to be the most sufficient solution here, as I did try a few other things, too. 