### PR TITLE
IGAPP-809: Languages json not existing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,6 +522,9 @@ jobs:
                 command: yarn lint
                 name: Lint
             - run:
+                command: yarn workspace web stylelint
+                name: Stylelint
+            - run:
                 command: yarn workspaces run ts:check
                 name: TS check
             - unit_test:

--- a/.circleci/src/jobs/check.yml
+++ b/.circleci/src/jobs/check.yml
@@ -18,6 +18,9 @@ steps:
       name: Lint
       command: yarn lint
   - run:
+      name: Stylelint
+      command: yarn workspace web stylelint
+  - run:
       name: TS check
       command: yarn workspaces run ts:check
   - unit_test:

--- a/api-client/src/Endpoint.ts
+++ b/api-client/src/Endpoint.ts
@@ -3,7 +3,7 @@ import { MapParamsToUrlType } from './MapParamsToUrlType'
 import { MapResponseType } from './MapResponseType'
 import Payload from './Payload'
 import FetchError from './errors/FetchError'
-import ResponseError, { RequestOptionsType } from './errors/ResponseError'
+import ResponseError from './errors/ResponseError'
 import { request as fetch } from './request'
 
 /**
@@ -49,7 +49,7 @@ class Endpoint<P, T> {
       return new Payload(false, url, this.responseOverride, null)
     }
 
-    const requestOptions: RequestOptionsType = this.mapParamsToBody
+    const requestOptions = this.mapParamsToBody
       ? {
           method: 'POST',
           body: this.mapParamsToBody(params)
@@ -59,18 +59,11 @@ class Endpoint<P, T> {
         }
 
     const response = await fetch(url, requestOptions).catch((e: Error) => {
-      // TODO IGAPP-809: Remove again
-      // eslint-disable-next-line no-console
-      console.debug('An error occurred while fetching from ', url, ' with method ', requestOptions.method)
-      if (requestOptions.method === 'POST') {
-        // TODO IGAPP-809: Remove again
-        // eslint-disable-next-line no-console
-        console.debug(' and body ', requestOptions.body)
-      }
-
       throw new FetchError({
         endpointName: this.stateName,
-        innerError: e
+        innerError: e,
+        url,
+        requestOptions
       })
     })
 
@@ -84,18 +77,11 @@ class Endpoint<P, T> {
     }
 
     const json = await response.json().catch(e => {
-      // TODO IGAPP-809: Remove again
-      // eslint-disable-next-line no-console
-      console.debug('An error occurred while fetching from ', url, ' with method ', requestOptions.method)
-      if (requestOptions.method === 'POST') {
-        // TODO IGAPP-809: Remove again
-        // eslint-disable-next-line no-console
-        console.debug(' and body ', requestOptions.body)
-      }
-
       throw new FetchError({
         endpointName: this.stateName,
-        innerError: e
+        innerError: e,
+        url,
+        requestOptions
       })
     })
 

--- a/api-client/src/Endpoint.ts
+++ b/api-client/src/Endpoint.ts
@@ -59,6 +59,15 @@ class Endpoint<P, T> {
         }
 
     const response = await fetch(url, requestOptions).catch((e: Error) => {
+      // TODO IGAPP-809: Remove again
+      // eslint-disable-next-line no-console
+      console.debug('An error occurred while fetching from ', url, ' with method ', requestOptions.method)
+      if (requestOptions.method === 'POST') {
+        // TODO IGAPP-809: Remove again
+        // eslint-disable-next-line no-console
+        console.debug(' and body ', requestOptions.body)
+      }
+
       throw new FetchError({
         endpointName: this.stateName,
         innerError: e
@@ -75,6 +84,15 @@ class Endpoint<P, T> {
     }
 
     const json = await response.json().catch(e => {
+      // TODO IGAPP-809: Remove again
+      // eslint-disable-next-line no-console
+      console.debug('An error occurred while fetching from ', url, ' with method ', requestOptions.method)
+      if (requestOptions.method === 'POST') {
+        // TODO IGAPP-809: Remove again
+        // eslint-disable-next-line no-console
+        console.debug(' and body ', requestOptions.body)
+      }
+
       throw new FetchError({
         endpointName: this.stateName,
         innerError: e

--- a/api-client/src/__tests__/Endpoint.spec.ts
+++ b/api-client/src/__tests__/Endpoint.spec.ts
@@ -134,7 +134,7 @@ describe('Endpoint', () => {
     mockedFetch.mockRejectedValue(error)
     const endpoint = new Endpoint('endpoint', defaultMapParamsToUrl, null, defaultJsonMapper)
     await expect(endpoint.request(params)).rejects.toThrowError(
-      new FetchError({ endpointName: 'endpoint', innerError: error })
+      new FetchError({ endpointName: 'endpoint', innerError: error, url, requestOptions: { method: 'GET' } })
     )
   })
 
@@ -157,7 +157,7 @@ describe('Endpoint', () => {
     mockedFetch.mockImplementation(async () => responseFailingJson)
     const endpoint = new Endpoint('endpoint', defaultMapParamsToUrl, null, defaultJsonMapper)
     await expect(endpoint.request(params)).rejects.toThrowError(
-      new FetchError({ endpointName: 'endpoint', innerError: error })
+      new FetchError({ endpointName: 'endpoint', innerError: error, url, requestOptions: { method: 'GET' } })
     )
   })
 })

--- a/api-client/src/__tests__/request.spec.ts
+++ b/api-client/src/__tests__/request.spec.ts
@@ -1,0 +1,49 @@
+import { request, setUserAgent } from '../request'
+
+describe('request', () => {
+  const url = 'https://example.com'
+  const bodyObject = { property1: 'property1' }
+  const body = JSON.stringify(bodyObject)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call fetch correctly', async () => {
+    const requestOptions = { method: 'POST', body: JSON.stringify(body) }
+    await request(url, requestOptions)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(url, requestOptions)
+
+    const requestOptions2 = { method: 'GET' }
+    const url2 = 'https://example.com/another-url'
+    await request(url2, requestOptions2)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenCalledWith(url2, requestOptions2)
+  })
+
+  it('should set user agent correclty', async () => {
+    setUserAgent('my-user-agent')
+    const requestOptions = { method: 'POST', body: JSON.stringify(body) }
+    await request(url, { ...requestOptions, headers: { custom: 'custom' } })
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(url, {
+      headers: {
+        custom: 'custom',
+        'User-Agent': 'my-user-agent'
+      },
+      ...requestOptions
+    })
+
+    const requestOptions2 = { method: 'GET' }
+    const url2 = 'https://example.com/another-url'
+    await request(url2, { ...requestOptions2, headers: { 'User-Agent': 'another-user-agent' } })
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenCalledWith(url2, {
+      headers: {
+        'User-Agent': 'my-user-agent'
+      },
+      ...requestOptions2
+    })
+  })
+})

--- a/api-client/src/endpoints/__tests__/createTrackingEndpoint.spec.ts
+++ b/api-client/src/endpoints/__tests__/createTrackingEndpoint.spec.ts
@@ -30,11 +30,7 @@ describe('createTrackingEndpoint', () => {
     expect.assertions(1)
     return createTrackingEndpoint()
       .request(signal)
-      .catch(e =>
-        expect(e.message).toContain(
-          'FetchError: Failed to load the request for the tracking endpoint. Das Internet ist kaputt!!!1!!!11elf!'
-        )
-      )
+      .catch(e => expect(e.message).toContain('FetchError: Failed to POST the request for the tracking endpoint'))
   })
   it('should throw response error if response is not ok', async () => {
     ;((fetch as unknown) as FetchMock).mockResponseOnce('Invalid endpoint', {

--- a/api-client/src/endpoints/createTrackingEndpoint.ts
+++ b/api-client/src/endpoints/createTrackingEndpoint.ts
@@ -55,14 +55,17 @@ const createTrackingEndpoint = (url: string = JPAL_TRACKING_ENDPOINT_URL): Track
       }
     }
     const body = JSON.stringify(mappedSignal)
-    const response = await fetch(url, {
+    const requestOptions = {
       method: 'POST',
       body,
       headers: JSON_HEADERS
-    }).catch((e: Error) => {
+    }
+    const response = await fetch(url, requestOptions).catch((e: Error) => {
       throw new FetchError({
         endpointName: TRACKING_ENDPOINT_NAME,
-        innerError: e
+        innerError: e,
+        requestOptions,
+        url
       })
     })
 

--- a/api-client/src/errors/FetchError.ts
+++ b/api-client/src/errors/FetchError.ts
@@ -40,7 +40,7 @@ class FetchError extends Error {
       stringifiedFormData = ` and the formData ${JSON.stringify(requestOptions.body)}`
     }
 
-    return `ResponseError: Failed to ${requestOptions.method} the request for the ${endpointName} endpoint with the url
+    return `FetchError: Failed to ${requestOptions.method} the request for the ${endpointName} endpoint with the url
      ${url}${stringifiedFormData}. ${innerError.message}`
   }
 

--- a/api-client/src/errors/FetchError.ts
+++ b/api-client/src/errors/FetchError.ts
@@ -1,9 +1,18 @@
-class FetchError extends Error {
+type FetchErrorParams = {
+  endpointName: string
   innerError: Error
-  getMessage = (endpointName: string, innerError: Error): string =>
-    `FetchError: Failed to load the request for the ${endpointName} endpoint. ${innerError.message}`
+  url: string
+  requestOptions: Partial<RequestInit>
+}
 
-  constructor(params: { endpointName: string; innerError: Error }) {
+class FetchError extends Error {
+  _endpointName: string
+  _url: string
+  _requestOptions: Partial<RequestInit>
+  _innerError: Error
+  _message: string
+
+  constructor(params: FetchErrorParams) {
     super()
 
     // captureStackTrace is not always defined on mobile
@@ -14,8 +23,45 @@ class FetchError extends Error {
       Error.captureStackTrace(this, FetchError)
     }
 
-    this.message = this.getMessage(params.endpointName, params.innerError)
-    this.innerError = params.innerError
+    this._message = this.createMessage(params)
+    this._endpointName = params.endpointName
+    this._url = params.url
+    this._requestOptions = params.requestOptions
+    this._message = this.createMessage(params)
+    this._innerError = params.innerError
+  }
+
+  createMessage({ requestOptions, url, endpointName, innerError }: FetchErrorParams): string {
+    let stringifiedFormData = ''
+
+    if (requestOptions.method === 'POST' && typeof requestOptions.body === 'string') {
+      stringifiedFormData = ` and the body ${requestOptions.body}`
+    } else if (requestOptions.method === 'POST') {
+      stringifiedFormData = ` and the formData ${JSON.stringify(requestOptions.body)}`
+    }
+
+    return `ResponseError: Failed to ${requestOptions.method} the request for the ${endpointName} endpoint with the url
+     ${url}${stringifiedFormData}. ${innerError.message}`
+  }
+
+  get message(): string {
+    return this._message
+  }
+
+  get endpointName(): string {
+    return this._endpointName
+  }
+
+  get innerError(): Error {
+    return this._innerError
+  }
+
+  get url(): string {
+    return this._url
+  }
+
+  get requestOptions(): Partial<RequestInit> {
+    return this._requestOptions
   }
 }
 

--- a/api-client/src/errors/ResponseError.ts
+++ b/api-client/src/errors/ResponseError.ts
@@ -1,23 +1,15 @@
-export type RequestOptionsType =
-  | {
-      method: 'GET'
-    }
-  | {
-      method: 'POST'
-      body: FormData | string
-    }
 type ResponseErrorParamsType = {
   endpointName: string
   response: Response
   url: string
-  requestOptions: RequestOptionsType
+  requestOptions: Partial<RequestInit>
 }
 
 class ResponseError extends Error {
   _endpointName: string
   _response: Response
   _url: string
-  _requestOptions: RequestOptionsType
+  _requestOptions: Partial<RequestInit>
   _message: string
 
   constructor(params: ResponseErrorParamsType) {
@@ -72,7 +64,7 @@ class ResponseError extends Error {
     return this._url
   }
 
-  get requestOptions(): RequestOptionsType {
+  get requestOptions(): Partial<RequestInit> {
     return this._requestOptions
   }
 }

--- a/api-client/src/request.ts
+++ b/api-client/src/request.ts
@@ -9,5 +9,8 @@ export const setUserAgent = (userAgent: string): void => {
   }
 }
 
-export const request = (url: string, options: Partial<RequestInit>): Promise<Response> =>
-  fetch(url, merge(defaultRequestOptions, options))
+export const request = (url: string, options: Partial<RequestInit>): Promise<Response> => {
+  // merge mutates the first passed object which may lead to errors e.g. by setting body on a GET request
+  const requestOptions = {}
+  return fetch(url, merge(requestOptions, options, defaultRequestOptions))
+}

--- a/native/src/Navigator.tsx
+++ b/native/src/Navigator.tsx
@@ -89,7 +89,9 @@ const Navigator = (props: PropsType): ReactElement | null => {
 
   useEffect(() => {
     fetchCities(false)
+  }, [fetchCities])
 
+  useEffect(() => {
     const initialize = async () => {
       const usingHermes = typeof HermesInternal === 'object' && HermesInternal !== null
 
@@ -150,7 +152,7 @@ const Navigator = (props: PropsType): ReactElement | null => {
     }
 
     initialize().catch(error => setErrorMessage(error.message))
-  }, [fetchCities, setInitialRoute, setErrorMessage])
+  }, [setInitialRoute, setErrorMessage])
 
   // The following is used to have correct mapping from categories route mapping in redux state to the actual routes
   useEffect(() => {

--- a/native/src/constants/webview.ts
+++ b/native/src/constants/webview.ts
@@ -28,8 +28,7 @@ export const createPostSource = (
         In this case Android figures the out which content type to use */
   })
 })
-export const createGetSource = (uri: string, body: string): WebViewSource => ({
+export const createGetSource = (uri: string): WebViewSource => ({
   uri,
-  method: 'GET',
-  body
+  method: 'GET'
 })

--- a/native/src/routes/ExternalOffer.tsx
+++ b/native/src/routes/ExternalOffer.tsx
@@ -30,7 +30,6 @@ const ExternalOffer = (props: PropsType): ReactElement => {
     return () => backHandler.remove()
   }, [canGoBack])
   const { url, postData } = props
-  const body = !postData ? '' : stringify(fromPairs([...postData.entries()]))
   const onNavigationStateChange = useCallback(
     (navState: WebViewNavigation) => {
       setCanGoBack(navState.canGoBack)
@@ -39,7 +38,7 @@ const ExternalOffer = (props: PropsType): ReactElement => {
   )
   return (
     <WebView
-      source={postData ? createPostSource(url, body) : createGetSource(url, body)}
+      source={postData ? createPostSource(url, stringify(fromPairs([...postData.entries()]))) : createGetSource(url)}
       javaScriptEnabled
       dataDetectorTypes='none'
       domStorageEnabled={false}

--- a/native/src/utils/__tests__/sendTrackingSignal.spec.ts
+++ b/native/src/utils/__tests__/sendTrackingSignal.spec.ts
@@ -131,7 +131,9 @@ describe('sendTrackingSignal', () => {
       })
       const error = new FetchError({
         endpointName: 'endpoint',
-        innerError: new Error('Internet kaputt')
+        innerError: new Error('Internet kaputt'),
+        url: 'url',
+        requestOptions: { method: 'POST' }
       })
       mockRequest.mockRejectedValueOnce(error)
       await sendRequest(signal)

--- a/web/src/components/MapPopup.tsx
+++ b/web/src/components/MapPopup.tsx
@@ -11,8 +11,7 @@ const Popup = styled.div`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  bottom: 0px;
-  margin: 0 5% 5% 5%;
+  margin: 0 5% 5%;
   width: 90%;
   height: 12vh;
   border-radius: 8px;

--- a/web/src/components/MapPopup.tsx
+++ b/web/src/components/MapPopup.tsx
@@ -11,6 +11,7 @@ const Popup = styled.div`
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  bottom: 0;
   margin: 0 5% 5%;
   width: 90%;
   height: 12vh;

--- a/web/src/components/__tests__/FailureSwitcher.spec.tsx
+++ b/web/src/components/__tests__/FailureSwitcher.spec.tsx
@@ -39,7 +39,12 @@ describe('FailureSwitcher', () => {
   })
 
   it('should not report fetch errors to sentry', async () => {
-    const error = new FetchError({ endpointName: 'cities', innerError: new Error('asdf') })
+    const error = new FetchError({
+      endpointName: 'cities',
+      innerError: new Error('asdf'),
+      url: 'url',
+      requestOptions: { method: 'GET' }
+    })
     const { getByText } = render(<FailureSwitcher error={error} />, { wrapper: MemoryRouter })
 
     expect(getByText(`error:${fromError(error)}`)).toBeTruthy()


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

~~This PR probably does not fix anything and is rather meant to gather additional information. This bug should not be critical as I tried and afaics all errors logged are caught and handled correctly.~~

~~The error that the `languages.json does not exist` always occurs after another error during fetching, most of the time after the following error: `Failed to load the request for the languages endpoint. Body not allowed for GET or HEAD requests` (I also found [one occurrence](https://sentry.tuerantuer.org/organizations/digitalfabrik/issues/264/events/25db970a57814cc89d608f53896a1686/?project=2) of the same error for the cities endpoint, so it should not be the fault of the language endpoint). Nearly always it also seems like `loadCityContent` (or `loadCities` for the one occurrence) are called and run twice.~~

~~The whole thing is really weird, first because of the iniital GET/Body request thingy, second because the following `languages.json does not exist` error only occurs after this error (and not e.g. after regular fetch errors) and third because sagas are run twice even though we are using `takeLatest` which should cancel any previous sagas. I suspect that the issue is somewhere in executing `loadLanguages` twice though.~~

See below :)