### PR TITLE
IGAPP-839: Fixed missing overflow for p-tags in webview

### DIFF
--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -13,7 +13,7 @@ const renderJS = (cacheDictionary: Record<string, string>) => `
 
     window.ReactNativeWebView.postMessage(JSON.stringify({ type, message: message }))
   }
-  
+
   // Catching occurring errors
   (function() {
     window.onerror = function(msg, url, lineNo, columnNo, error) {
@@ -21,7 +21,8 @@ const renderJS = (cacheDictionary: Record<string, string>) => `
       var string = msg.toLowerCase()
       var substring = "script error"
       if (string.indexOf(substring) > -1) {
-        reportError('Script Error: See Browser Console for Detail: ' + msg + JSON.stringify(error), '${ERROR_MESSAGE_TYPE}')
+        reportError('Script Error: See Browser Console for Detail: ' + msg + JSON.stringify(error),
+          '${ERROR_MESSAGE_TYPE}')
       } else {
         var message = [
           'Message: ' + msg,
@@ -52,7 +53,8 @@ const renderJS = (cacheDictionary: Record<string, string>) => `
           item.href = newResource
         }
       } catch (e) {
-        reportError(e.message + 'occurred while decoding and looking for ' + item.href + ' in the dictionary', '${WARNING_MESSAGE_TYPE}')
+        reportError(e.message + 'occurred while decoding and looking for ' + item.href + ' in the dictionary',
+          '${WARNING_MESSAGE_TYPE}')
       }
     }
 
@@ -64,7 +66,8 @@ const renderJS = (cacheDictionary: Record<string, string>) => `
           item.src = newResource
         }
       } catch (e) {
-        reportError(e.message + 'occurred while decoding and looking for ' + item.src + ' in the dictionary', '${WARNING_MESSAGE_TYPE}')
+        reportError(e.message + 'occurred while decoding and looking for ' + item.src + ' in the dictionary',
+          '${WARNING_MESSAGE_TYPE}')
       }
     }
   })();
@@ -170,6 +173,7 @@ const renderHtml = (
 
       p {
         margin: ${theme.fonts.standardParagraphMargin} 0;
+        overflow: auto;
       }
 
       img {

--- a/release-notes/unreleased/IGAPP-839-Fix-Paragraph-Overflow-Native.yml
+++ b/release-notes/unreleased/IGAPP-839-Fix-Paragraph-Overflow-Native.yml
@@ -1,0 +1,7 @@
+issue_key: IGAPP-839
+show_in_stores: true
+platforms:
+  - ios
+  - android
+en: Fixed faulty display of paragraphs in webview.
+de: Fehlerhafte Darstellung von Paragraphen im Webview wurde behoben.

--- a/release-notes/unreleased/IGAPP-839-Fix-Paragraph-Overflow-Native.yml
+++ b/release-notes/unreleased/IGAPP-839-Fix-Paragraph-Overflow-Native.yml
@@ -3,5 +3,5 @@ show_in_stores: true
 platforms:
   - ios
   - android
-en: Fixed faulty display of paragraphs in webview.
-de: Fehlerhafte Darstellung von Paragraphen im Webview wurde behoben.
+en: Fixed faulty display in certain cases.
+de: Fehlerhafte Darstellung in bestimmten Fällen wurde behoben.


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Go to Kreis Höxter -> Asyl und Migration -> Information zum Asylverfahren
Switch language to FA

Text should be displayed correctly on ios & android (it was buggy on both systems!)

Tested on android emulator, ios native & emulator